### PR TITLE
CocoaPods 1.0 support.

### DIFF
--- a/RNQuickAction.podspec
+++ b/RNQuickAction.podspec
@@ -6,6 +6,9 @@ Pod::Spec.new do |s|
   s.name         = "RNQuickAction"
   s.version      = version
   s.homepage     = "https://github.com/jordanbyron/react-native-quick-actions"
+  s.summary      = "A react-native interface for Touch 3D home screen quick actions"
+  s.license      = "MIT"
+  s.author       = { "Jordan Byron" => "jordan.byron@gmail.com" }
   s.platform     = :ios, "9.0"
   s.source       = { :git => "https://github.com/jordanbyron/react-native-quick-actions.git", :tag => "#{s.version}" }
   s.source_files = 'RNQuickAction/RNQuickAction/*.{h,m}'


### PR DESCRIPTION
CocoaPods 1.0 was recently released and introduces some changes to podspec requirements. This PR addresses those.