### PR TITLE
Support RN 0.40, change header import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ __This project currently only supports iOS 9+__
 
 ![](http://i.imgur.com/holmBPD.png)
 
+## Supported React Native Versions
+
+| React Native version(s) | Supporting react-native-quick-actions version(s) |
+|-------------------------|--------------------------------------------------|
+| < v0.40                   | v0.1.5                                         |
+| v0.40+                    | v0.2.0+                                        |
+
 ## Installing
 
 First cd into your project's directory and grab the latest version of this code:

--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.h
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.h
@@ -6,7 +6,7 @@
 //  Copyright © 2015 react-native. All rights reserved.
 //
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNQuickActionManager : NSObject <RCTBridgeModule>
 +(void) onQuickActionPress:(UIApplicationShortcutItem *) shortcutItem completionHandler:(void (^)(BOOL succeeded)) completionHandler;

--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.m
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.m
@@ -6,11 +6,11 @@
 //  Copyright © 2015 react-native. All rights reserved.
 //
 
-#import "RCTBridge.h"
-#import "RCTConvert.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTUtils.h>
 #import "RNQuickActionManager.h"
-#import "RCTUtils.h"
 
 NSString *const RCTShortcutItemClicked = @"ShortcutItemClicked";
 


### PR DESCRIPTION
iOS native headers moved in RN 0.40

https://github.com/facebook/react-native/releases/tag/v0.40.0