### PR TITLE
Fix/android 4 4 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-quick-actions",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A react-native interface for Touch 3D home screen quick actions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Issue: on Android 4.4, there is an exception during startup due to undefined `class ShortcutInfo` being referenced in function `createShortcutInfo()`.

Fix: remove function `createShortcutInfo()` and put the body into where it is being referenced to avoid this issue.