### PR TITLE
Only send JS event if the intent was from the shortcut action

### DIFF
--- a/android/src/main/java/com/reactNativeQuickActions/AppShortcutsModule.java
+++ b/android/src/main/java/com/reactNativeQuickActions/AppShortcutsModule.java
@@ -135,7 +135,7 @@ class AppShortcutsModule extends ReactContextBaseJavaModule {
     }
 
     private void sendJSEvent(Intent intent) {
-        if (!isShortcutSupported()) {
+        if (!ACTION_SHORTCUT.equals(intent.getAction()) || !isShortcutSupported()) {
             return;
         }
 


### PR DESCRIPTION
**Bug**:
Events from the  DeviceEventEmitter event `quickActionShortcut` are being sent from Android for any `onNewIntent` event. If the Intent has a type matching a shortcut item. It should only need to send the event when it originated from the quick action.

```javascript
DeviceEventEmitter.addListener(
 'quickActionShortcut',
 this._handleQuickAction,
)
```

I've added a check for the Intent Action, the same as the initial intent check - https://github.com/madriska/react-native-quick-actions/blob/master/android/src/main/java/com/reactNativeQuickActions/AppShortcutsModule.java#L69