### PR TITLE
Check api level before clearing shortcut items

### DIFF
--- a/android/src/main/java/com/reactNativeQuickActions/AppShortcutsModule.java
+++ b/android/src/main/java/com/reactNativeQuickActions/AppShortcutsModule.java
@@ -111,15 +111,17 @@ class AppShortcutsModule extends ReactContextBaseJavaModule {
                     .build());
         }
 
-        getReactApplicationContext().getSystemService(ShortcutManager.class)
-                .setDynamicShortcuts(shortcuts);
+        getShortcutManager().setDynamicShortcuts(shortcuts);
     }
 
     @ReactMethod
     @TargetApi(25)
     public void clearShortcutItems() {
-        getReactApplicationContext().getSystemService(ShortcutManager.class)
-                .removeAllDynamicShortcuts();
+        if (!isShortcutSupported()) {
+            return;
+        }
+
+        getShortcutManager().removeAllDynamicShortcuts();
         mShortcutItems = null;
     }
 
@@ -132,6 +134,11 @@ class AppShortcutsModule extends ReactContextBaseJavaModule {
 
     private boolean isShortcutSupported() {
         return Build.VERSION.SDK_INT >= 25;
+    }
+
+    @TargetApi(25)
+    private ShortcutManager getShortcutManager() {
+        return getReactApplicationContext().getSystemService(ShortcutManager.class);
     }
 
     private void sendJSEvent(Intent intent) {


### PR DESCRIPTION
Check api level before calling `removeAllDynamicShortcuts()`

Fix crash:
```
java.lang.RuntimeException Could not invoke ReactAppShortcuts.clearShortcutItems 
    BaseJavaModule.java:382 com.facebook.react.bridge.BaseJavaModule$JavaMethod.invoke
    JavaModuleWrapper.java:138 com.facebook.react.cxxbridge.JavaModuleWrapper.invoke
    NativeRunnable.java:-2 com.facebook.react.bridge.queue.NativeRunnable.run
    Handler.java:733 android.os.Handler.handleCallback
    Handler.java:95 android.os.Handler.dispatchMessage
    MessageQueueThreadHandler.java:31 com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage
    Looper.java:136 android.os.Looper.loop
    MessageQueueThreadImpl.java:208 com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run
    Thread.java:841 java.lang.Thread.run

Caused: java.lang.NoClassDefFoundError android.content.pm.ShortcutManager 
    AppShortcutsModule.java:121 com.reactNativeQuickActions.AppShortcutsModule.clearShortcutItems
    Method.java:-2 java.lang.reflect.Method.invokeNative
    Method.java:515 java.lang.reflect.Method.invoke
    BaseJavaModule.java:368 com.facebook.react.bridge.BaseJavaModule$JavaMethod.invoke
    JavaModuleWrapper.java:138 com.facebook.react.cxxbridge.JavaModuleWrapper.invoke
    NativeRunnable.java:-2 com.facebook.react.bridge.queue.NativeRunnable.run
    Handler.java:733 android.os.Handler.handleCallback
    Handler.java:95 android.os.Handler.dispatchMessage
    MessageQueueThreadHandler.java:31 com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage
    Looper.java:136 android.os.Looper.loop
    MessageQueueThreadImpl.java:208 com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run
    Thread.java:841 java.lang.Thread.run
```