### PR TITLE
Fix `java.lang.NoClassDefFoundError: android.content.pm.ShortcutManager`

### DIFF
--- a/android/src/main/java/com/reactNativeQuickActions/AppShortcutsModule.java
+++ b/android/src/main/java/com/reactNativeQuickActions/AppShortcutsModule.java
@@ -111,7 +111,7 @@ class AppShortcutsModule extends ReactContextBaseJavaModule {
                     .build());
         }
 
-        getShortcutManager().setDynamicShortcuts(shortcuts);
+        getReactApplicationContext().getSystemService(ShortcutManager.class).setDynamicShortcuts(shortcuts);
     }
 
     @ReactMethod
@@ -121,7 +121,7 @@ class AppShortcutsModule extends ReactContextBaseJavaModule {
             return;
         }
 
-        getShortcutManager().removeAllDynamicShortcuts();
+        getReactApplicationContext().getSystemService(ShortcutManager.class).removeAllDynamicShortcuts();
         mShortcutItems = null;
     }
 
@@ -134,11 +134,6 @@ class AppShortcutsModule extends ReactContextBaseJavaModule {
 
     private boolean isShortcutSupported() {
         return Build.VERSION.SDK_INT >= 25;
-    }
-
-    @TargetApi(25)
-    private ShortcutManager getShortcutManager() {
-        return getReactApplicationContext().getSystemService(ShortcutManager.class);
     }
 
     private void sendJSEvent(Intent intent) {


### PR DESCRIPTION
Sorry, my clean up on the last PR made things worse.

Having `ShortcutManager` as a return type in the method signature causes `java.lang.NoClassDefFoundError: android.content.pm.ShortcutManager`