### PR TITLE
Fix currentActivity null pointer exception

### DIFF
--- a/android/src/main/java/com/reactNativeQuickActions/AppShortcutsModule.java
+++ b/android/src/main/java/com/reactNativeQuickActions/AppShortcutsModule.java
@@ -89,6 +89,11 @@ class AppShortcutsModule extends ReactContextBaseJavaModule {
             return;
         }
 
+        Activity currentActivity = getCurrentActivity();
+        if (currentActivity == null) {
+            return;
+        }
+
         Context context = getReactApplicationContext();
         mShortcutItems = new ArrayList<>(items.size());
         List<ShortcutInfo> shortcuts = new ArrayList<>(items.size());
@@ -99,7 +104,7 @@ class AppShortcutsModule extends ReactContextBaseJavaModule {
 
             int iconResId = context.getResources()
                     .getIdentifier(item.icon, "drawable", context.getPackageName());
-            Intent intent = new Intent(context, getCurrentActivity().getClass());
+            Intent intent = new Intent(context, currentActivity.getClass());
             intent.setAction(ACTION_SHORTCUT);
             intent.putExtra(SHORTCUT_TYPE, item.type);
 


### PR DESCRIPTION
Seeing a lot of crashes on crashlytics:
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference
       at com.reactNativeQuickActions.AppShortcutsModule.setShortcutItems(AppShortcutsModule.java:102)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.facebook.react.bridge.BaseJavaModule$JavaMethod.invoke(BaseJavaModule.java:368)
       at com.facebook.react.cxxbridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:138)
       at com.facebook.react.bridge.queue.NativeRunnable.run(NativeRunnable.java)
       at android.os.Handler.handleCallback(Handler.java:751)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:31)
       at android.os.Looper.loop(Looper.java:154)
       at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:208)
       at java.lang.Thread.run(Thread.java:761)
```

`getCurrentActivity()` is `@Nullable` so we should check.

Guessing the method was called at the same time the app was closing.

Thanks in advance @jordanbyron 