### PR TITLE
Support React Native 0.47

### DIFF
--- a/android/src/main/java/com/reactNativeQuickActions/AppShortcutsPackage.java
+++ b/android/src/main/java/com/reactNativeQuickActions/AppShortcutsPackage.java
@@ -16,7 +16,6 @@ public class AppShortcutsPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList(new AppShortcutsModule(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Closes #43

Removes the `@Override` - this change is backward compatible 

https://github.com/getsentry/react-native-sentry/pull/172 - same as Sentry's approach