### PR TITLE
Added requiresMainQueueSetup

### DIFF
--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.m
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.m
@@ -43,6 +43,10 @@ RCT_EXPORT_MODULE();
     return self;
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];


### PR DESCRIPTION
Added requiresMainQueueSetup to prevent warning and future side-effects in RNQuickActionManager.